### PR TITLE
Adding IdleComp article to Web Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ A curated list of latest posts, blogs and repositories related to [JavaScript][j
 ## Web Development
 
 - [Idle Until Urgent: A Performance Strategy](https://philipwalton.com/articles/idle-until-urgent/).&nbsp;&nbsp;:new:
+- [Introducing `idle-comp`: A Composable Idle Until Urgent Aproach](https://munizart.github.io/2018/10/11/introducing-idle-comp/).&nbsp;&nbsp;:new:
 - [Electron 3.0: The Cross Platform Desktop App Framework](https://electronjs.org/blog/electron-3-0).&nbsp;&nbsp;:new:
 - [Write less code, ship more apps: How Vulcan.js makes me an efficient developer](https://medium.com/dailyjs/write-less-code-ship-more-apps-how-vulcan-js-makes-me-an-efficient-developer-71c829c76417)
 - [Tracking client JavaScript bundle size during development](https://medium.com/@LopezTech/tracking-client-javascript-bundle-size-during-development-f40c6fa69ba6)


### PR DESCRIPTION
I think this article should be included as a follow up to Walton's "Idle Until Urgent".

This post introduce a different perspective, focused on function composition to create small tasks that will compute on browser's idle time.

[Link to post: ](https://munizart.github.io/2018/10/11/introducing-idle-comp/)https://munizart.github.io/2018/10/11/introducing-idle-comp/

Thank you,