### PR TITLE
Add Markstream to Vue.js resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 10+ pe
 
 - [Toastflow: TS-first toast engine for Vue 3](https://github.com/adrianjanocko/toastflow)
 - [Vue-stream-markdown: Streaming markdown renderer for Vue 3](https://github.com/jinghaihan/vue-stream-markdown)
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for AI chat across Vue, React, Svelte and Angular.
 - [Vue CLI 3.0 is here!](https://medium.com/the-vue-point/vue-cli-3-0-is-here-c42bebe28fbb)
 - [Vue 3 Migration Build: Safely upgrade your app to Vue 3 (Pt. 1)](https://www.vuemastery.com/blog/vue-3-migration-build/)
 - [How to Structure a Large Scale Vue.js Application](https://vueschool.io/articles/vuejs-tutorials/how-to-structure-a-large-scale-vue-js-application/)


### PR DESCRIPTION
## Link

https://github.com/Simon-He95/markstream-vue

## Why it should be included

Markstream is an actively maintained, MIT-licensed TypeScript project for streaming Markdown in AI chat interfaces. It handles incomplete Markdown while model tokens arrive and provides Vue, React, Svelte, and Angular packages with Mermaid, KaTeX, syntax highlighting, and SSR support.

The Vue.js section already includes another streaming Markdown renderer, so this is a relevant alternative for readers. I searched the README, issues, and pull requests and found no previous Markstream submission.

The new entry follows the Awesome List item format. Local `awesome-lint` reports only its repository-environment check; it reports no error for the added list item.

Disclosure: I maintain Markstream. Thank you for considering it!
